### PR TITLE
Added Crossplane service principal and ApplicationSets

### DIFF
--- a/gitops/bootstrap/control-plane/addons/oss/addons-crossplane-helm.yaml
+++ b/gitops/bootstrap/control-plane/addons/oss/addons-crossplane-helm.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: addons-crossplane-helm
+spec:
+  syncPolicy:
+    preserveResourcesOnDeletion: true
+  generators:
+    - merge:
+        mergeKeys: [server]
+        generators:
+          - clusters:
+              values:
+                addonChart: crossplane-helm
+                addonChartNamespace: crossplane-system
+                # anything not staging or prod use this version
+                addonChartVersion: 1.0.0
+                addonChartRepository: https://gitops-bridge-dev.github.io/gitops-bridge-helm-charts
+              selector:
+                matchExpressions:
+                  - key: akuity.io/argo-cd-cluster-name
+                    operator: NotIn
+                    values: [in-cluster]
+                  - key: enable_crossplane_helm_provider
+                    operator: In
+                    values: ['true']
+          - clusters:
+              selector:
+                matchLabels:
+                  environment: staging
+              values:
+                addonChartVersion: 1.0.0
+          - clusters:
+              selector:
+                matchLabels:
+                  environment: prod
+              values:
+                addonChartVersion: 1.0.0
+  template:
+    metadata:
+      name: addon-{{name}}-{{values.addonChart}}
+    spec:
+      project: default
+      sources:
+        - repoURL: '{{metadata.annotations.addons_repo_url}}'
+          targetRevision: '{{metadata.annotations.addons_repo_revision}}'
+          ref: values
+        - chart: '{{values.addonChart}}'
+          repoURL: '{{values.addonChartRepository}}'
+          targetRevision: '{{values.addonChartVersion}}'
+          helm:
+            releaseName: '{{values.addonChart}}'
+            ignoreMissingValueFiles: true
+            valueFiles:
+              - $values/{{metadata.annotations.addons_repo_basepath}}environments/default/addons/{{values.addonChart}}/values.yaml
+              - $values/{{metadata.annotations.addons_repo_basepath}}environments/{{metadata.labels.environment}}/addons/{{values.addonChart}}/values.yaml
+              - $values/{{metadata.annotations.addons_repo_basepath}}environments/clusters/{{name}}/addons/{{values.addonChart}}/values.yaml
+            values: |
+              provider:
+                package:
+                  registry: xpkg.upbound.io/crossplane-contrib/provider-helm
+                  version: "v0.16.0"
+          # fileParameters:
+          #  - name:
+          #    path:
+          # parameters
+          # valuesObject
+      destination:
+        namespace: '{{values.addonChartNamespace}}'
+        name: '{{name}}'
+      syncPolicy:
+        retry:
+          limit: 100
+        automated: {}
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true  # Big CRDs.

--- a/gitops/bootstrap/control-plane/addons/oss/addons-crossplane-kubernetes.yaml
+++ b/gitops/bootstrap/control-plane/addons/oss/addons-crossplane-kubernetes.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: addons-crossplane-kubernetes
+spec:
+  syncPolicy:
+    preserveResourcesOnDeletion: true
+  generators:
+    - merge:
+        mergeKeys: [server]
+        generators:
+          - clusters:
+              values:
+                addonChart: crossplane-kubernetes
+                addonChartNamespace: crossplane-system
+                # anything not staging or prod use this version
+                addonChartVersion: 1.0.0
+                addonChartRepository: https://gitops-bridge-dev.github.io/gitops-bridge-helm-charts
+              selector:
+                matchExpressions:
+                  - key: akuity.io/argo-cd-cluster-name
+                    operator: NotIn
+                    values: [in-cluster]
+                  - key: enable_crossplane_kubernetes_provider
+                    operator: In
+                    values: ['true']
+          - clusters:
+              selector:
+                matchLabels:
+                  environment: staging
+              values:
+                addonChartVersion: 1.0.0
+          - clusters:
+              selector:
+                matchLabels:
+                  environment: prod
+              values:
+                addonChartVersion: 1.0.0
+  template:
+    metadata:
+      name: addon-{{name}}-{{values.addonChart}}
+    spec:
+      project: default
+      sources:
+        - repoURL: '{{metadata.annotations.addons_repo_url}}'
+          targetRevision: '{{metadata.annotations.addons_repo_revision}}'
+          ref: values
+        - chart: '{{values.addonChart}}'
+          repoURL: '{{values.addonChartRepository}}'
+          targetRevision: '{{values.addonChartVersion}}'
+          helm:
+            releaseName: '{{values.addonChart}}'
+            ignoreMissingValueFiles: true
+            valueFiles:
+              - $values/{{metadata.annotations.addons_repo_basepath}}environments/default/addons/{{values.addonChart}}/values.yaml
+              - $values/{{metadata.annotations.addons_repo_basepath}}environments/{{metadata.labels.environment}}/addons/{{values.addonChart}}/values.yaml
+              - $values/{{metadata.annotations.addons_repo_basepath}}environments/clusters/{{name}}/addons/{{values.addonChart}}/values.yaml
+            values: |
+              provider:
+                package:
+                  registry: xpkg.upbound.io/crossplane-contrib/provider-kubernetes
+                  version: "v0.10.0"
+          # fileParameters:
+          #  - name:
+          #    path:
+          # parameters
+          # valuesObject
+      destination:
+        namespace: '{{values.addonChartNamespace}}'
+        name: '{{name}}'
+      syncPolicy:
+        retry:
+          limit: 100
+        automated: {}
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true  # Big CRDs.

--- a/terraform/aks.tf
+++ b/terraform/aks.tf
@@ -12,21 +12,28 @@ locals {
 
   argocd_namespace = "argocd"
 
+  aws_addons = {
+    enable_azure_crossplane_provider         = try(var.addons.enable_azure_crossplane_provider, false)
+    enable_azure_crossplane_upbound_provider = try(var.addons.enable_azure_crossplane_upbound_provider, false)
+  }
   oss_addons = {
-    enable_argocd                          = try(var.addons.enable_argocd, false)
-    enable_argo_rollouts                   = try(var.addons.enable_argo_rollouts, false)
-    enable_argo_events                     = try(var.addons.enable_argo_events, false)
-    enable_argo_workflows                  = try(var.addons.enable_argo_workflows, false)
-    enable_cluster_proportional_autoscaler = try(var.addons.enable_cluster_proportional_autoscaler, false)
-    enable_gatekeeper                      = try(var.addons.enable_gatekeeper, false)
-    enable_gpu_operator                    = try(var.addons.enable_gpu_operator, false)
-    enable_ingress_nginx                   = try(var.addons.enable_ingress_nginx, false)
-    enable_kyverno                         = try(var.addons.enable_kyverno, false)
-    enable_kube_prometheus_stack           = try(var.addons.enable_kube_prometheus_stack, false)
-    enable_metrics_server                  = try(var.addons.enable_metrics_server, false)
-    enable_prometheus_adapter              = try(var.addons.enable_prometheus_adapter, false)
-    enable_secrets_store_csi_driver        = try(var.addons.enable_secrets_store_csi_driver, false)
-    enable_vpa                             = try(var.addons.enable_vpa, false)
+    enable_argocd                            = try(var.addons.enable_argocd, false)
+    enable_argo_rollouts                     = try(var.addons.enable_argo_rollouts, false)
+    enable_argo_events                       = try(var.addons.enable_argo_events, false)
+    enable_argo_workflows                    = try(var.addons.enable_argo_workflows, false)
+    enable_cluster_proportional_autoscaler   = try(var.addons.enable_cluster_proportional_autoscaler, false)
+    enable_gatekeeper                        = try(var.addons.enable_gatekeeper, false)
+    enable_gpu_operator                      = try(var.addons.enable_gpu_operator, false)
+    enable_ingress_nginx                     = try(var.addons.enable_ingress_nginx, false)
+    enable_kyverno                           = try(var.addons.enable_kyverno, false)
+    enable_kube_prometheus_stack             = try(var.addons.enable_kube_prometheus_stack, false)
+    enable_metrics_server                    = try(var.addons.enable_metrics_server, false)
+    enable_prometheus_adapter                = try(var.addons.enable_prometheus_adapter, false)
+    enable_secrets_store_csi_driver          = try(var.addons.enable_secrets_store_csi_driver, false)
+    enable_vpa                               = try(var.addons.enable_vpa, false)
+    enable_crossplane                        = try(var.addons.enable_crossplane, false)
+    enable_crossplane_kubernetes_provider    = try(var.addons.enable_crossplane_kubernetes_provider, false)
+    enable_crossplane_helm_provider          = try(var.addons.enable_crossplane_helm_provider, false)
   }
   addons = local.oss_addons
 
@@ -147,15 +154,50 @@ module "gitops_bridge_bootstrap" {
   cluster = {
     cluster_name = module.aks.aks_name
     environment  = local.environment
-    metadata     = local.cluster_metadata
+    metadata     = merge(local.cluster_metadata,
+      {
+        crossplane_service_principal_client_id = azuread_service_principal.crossplane_service_principal.client_id
+        crossplane_service_principal_password  = azuread_service_principal_password.crossplane_service_principal_password.value
+      }
+    )       
     addons       = local.addons
   }
   apps = local.argocd_apps
   argocd = {
-    namespace = "argocd"
+    namespace = local.argocd_namespace
   }
 }
 
 ################################################################################
 # Crossplane: Service Principal
 ################################################################################
+data "azuread_client_config" "current" {}
+data "azurerm_subscription" "current" {}
+
+resource "azuread_application" "crossplane_application" {
+  display_name = var.crossplane_application_name
+  owners       = [data.azuread_client_config.current.object_id]
+}
+
+resource "azuread_service_principal" "crossplane_service_principal" {
+  client_id                    = azuread_application.crossplane_application.client_id
+  app_role_assignment_required = true
+  owners                       = [data.azuread_client_config.current.object_id]
+}
+
+resource "time_rotating" "crossplane_credentials_time_rotating" {
+  rotation_years = 2
+}
+
+resource "azuread_service_principal_password" "crossplane_service_principal_password" {
+  service_principal_id = azuread_service_principal.crossplane_service_principal.object_id
+  rotate_when_changed = {
+    rotation = time_rotating.crossplane_credentials_time_rotating.id
+  }
+}
+resource "azurerm_role_assignment" "crossplane_subscription_owner_role_assignment" {
+  scope                            = data.azurerm_subscription.current.id
+  role_definition_name             = "Owner"
+  principal_id                     = azuread_service_principal.crossplane_service_principal.object_id
+  skip_service_principal_aad_check = true
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,20 @@
+output "subscription_id" {
+  description = "Specifies the subscription id."
+  value = data.azurerm_subscription.current.id
+}
+
+output "tenant" {
+  description = "Specifies the tenant id."
+  value       = data.azurerm_client_config.current.tenant_id 
+}
+
+output "crossplane_service_principal_client_id" {
+  description = "Specifies the client id of the service principal."
+  value = azuread_service_principal.crossplane_service_principal.client_id
+}
+
+output "crossplane_service_principal_password" {
+  description = "Specifies the password for the service principal."
+  value = azuread_service_principal_password.crossplane_service_principal_password.value
+  sensitive = true
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,5 +1,9 @@
 terraform {
   required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 2.47.0"
+    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~> 3.56"
@@ -14,6 +18,12 @@ terraform {
     }
   }
   required_version = ">= 1.1.0"
+}
+
+data "azurerm_client_config" "current" {}
+
+provider "azuread" {
+  tenant_id = data.azurerm_client_config.current.tenant_id
 }
 
 provider "azurerm" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -26,8 +26,13 @@ variable "addons" {
   description = "Specifies the Kubernetes addons to install."
   type        = any
   default = {
-    enable_metrics_server               = false
-    enable_argocd = true
+    enable_argocd                            = true # installs argocd
+    enable_ingress_nginx                     = true # installs ingress-nginx
+    enable_crossplane_kubernetes_provider    = true # installs kubernetes provider
+    enable_crossplane_helm_provider          = true # installs helm provider
+    enable_crossplane                        = true # installs crossplane core
+    enable_azure_crossplane_provider         = true # installs azure contrib provider
+    enable_azure_crossplane_upbound_provider = true # installs azure upbound provider
   }
 }
 
@@ -102,7 +107,7 @@ variable "role_based_access_control_enabled" {
 variable "rbac_aad" {
   description = "Is Role Based Access Control based on Azure AD enabled?"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "prefix" {
@@ -201,3 +206,8 @@ variable "net_profile_service_cidr" {
   type        = string
 }
 
+variable "crossplane_application_name" {
+  description = "Specifies the name of the Crossplane Microsoft Entra ID registered application."
+  default     = "crossplane"
+  type        = string
+}


### PR DESCRIPTION
This PR adds the following changes:

- The `hashicorp/azuread` Terraform provider was added to the `providers.tf` file to allow the creation of the `Crossplane` service principal.
- The Microsoft Entra ID registered application and service principal used by `Crossplane` to create, read, update, and delete Azure resources.
- An `Owner` role assignment at the subscription level to the `Crossplane` service principal.
- The Helm charts for the `kubernetes` and `helm` upbound providers.